### PR TITLE
Adding AIConfig into the Table of Contents (TOC)

### DIFF
--- a/website/docs/alberta.md
+++ b/website/docs/alberta.md
@@ -8,7 +8,7 @@ import constants from '@site/core/tabConstants';
 
 # AlBERTa
 
-A 400M parameter state-of-the-art, encoder based model for calcuating the factual consistency of the generated answer against the provided context.
+A 400M parameter state-of-the-art, encoder based model designed for evaluating. This models works well without few-shot prompting or fine-tuning. However, for further performance improvements, the AlBERTa fleet of models are available for fine-tuning.
 
 ### Model Description
 

--- a/website/docs/models.md
+++ b/website/docs/models.md
@@ -21,8 +21,6 @@ The AlBERTa model series are language models optimized for evaluating the correc
 
 ## Models++
 
-
-
 | model | input length | latency | task |
 | --- | --- | --- | --- |
 | AlBERTa-512 | 512 token coontext | &lt;10ms | nli |

--- a/website/docs/quickstart.md
+++ b/website/docs/quickstart.md
@@ -16,4 +16,5 @@ First, you'll need a LastMile AI token to get started.
 1. Sign up for a [LastMile AI account](https://lastmileai.dev/auth/signin?callbackUrl=https%3A%2F%2Flastmileai.dev%2Fworkbooks%2Fworkshop) with your email
 2. Get a LastMile AI API Token from the [Settings Page](https://lastmileai.dev/settings?page=tokens)
 
-## 
+### 
+

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -51,6 +51,11 @@ const sidebars: SidebarsConfig = {
     'sdk',
     'workbooks',
     {
+      type: 'link',
+      label: 'AIConfig',
+      href: 'https://aiconfig.lastmileai.dev/docs/basics',
+    },
+    {
       type: "category",
       label: "API Specs",
       link: {


### PR DESCRIPTION
## Summary
Adding AIConfig into the Table of Contents (TOC)

## Changelist
- Adding AIConfig to the Table of Contents
- Blurb update for AlBerta model

## Test Plan
<img width="1350" alt="image" src="https://github.com/user-attachments/assets/96e50a5d-a3ef-4703-833f-ee9a0f9f1098">

```bash

```

---
