### PR TITLE
Detect and use system theme for docs

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -7,7 +7,7 @@ import type * as Plugin from "@docusaurus/types/src/plugin";
 import type * as OpenApiPlugin from "docusaurus-plugin-openapi-docs";
 
 const config: Config = {
-  title: "AutoEval",
+  title: "LastMile AI Platform",
   tagline:
     "Train and Deploy fine-tuned Evaluator Models to Evaluate, Test, and Guard your LLM applications.",
   favicon: "img/lm_favicon.png",

--- a/website/src/theme/Layout/index.tsx
+++ b/website/src/theme/Layout/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import Layout from "@theme-original/Layout";
 import type LayoutType from "@theme/Layout";
 import type { WrapperProps } from "@docusaurus/types";
@@ -6,6 +6,34 @@ import type { WrapperProps } from "@docusaurus/types";
 type Props = WrapperProps<typeof LayoutType>;
 
 export default function LayoutWrapper(props: Props): JSX.Element {
+  useEffect(() => {
+    // Detect system theme and apply it
+    const systemPrefersDark = window.matchMedia(
+      "(prefers-color-scheme: dark)"
+    ).matches;
+    document.documentElement.setAttribute(
+      "data-theme",
+      systemPrefersDark ? "dark" : "light"
+    );
+
+    // Listen for theme changes and update
+    const handleThemeChange = (e: MediaQueryListEvent) => {
+      document.documentElement.setAttribute(
+        "data-theme",
+        e.matches ? "dark" : "light"
+      );
+    };
+
+    // Add event listener for theme changes
+    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+    mediaQuery.addEventListener("change", handleThemeChange);
+
+    // Cleanup event listener on unmount
+    return () => {
+      mediaQuery.removeEventListener("change", handleThemeChange);
+    };
+  }, []);
+
   return (
     <>
       <Layout {...props} />


### PR DESCRIPTION
## Summary

The current docs embed in the web app doesn't respect the system theme: 

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/NHhrpocxsJ6TLH8q2JXX/29e27d8e-1244-46e0-9c35-3172f3eb5bfb.png)

In general the docsite doesn't update based on system theme preferences. This change adds an event listener to respond to these changes.

## Test Plan

* Toggled system theme

---
