### PR TITLE
Add node.js code samples for all AutoEval docs

### DIFF
--- a/website/docs/api-keys.mdx
+++ b/website/docs/api-keys.mdx
@@ -26,7 +26,7 @@ export LASTMILE_API_TOKEN="your_api_key"
 ```
 
 </TabItem>
-  <TabItem value="python">
+<TabItem value="python">
   
   ```python
 from lastmile import Lastmile
@@ -39,6 +39,24 @@ client = AutoEval(api_token="api_token_if_LASTMILE_API_TOKEN_not_set")
 client = Lastmile(
     bearer_token="api_token_if_LASTMILE_API_TOKEN_not_set",
 )
+```
+
+</TabItem>
+<TabItem value="node.js">
+  
+  ```typescript
+import { Lastmile } from 'lastmile';
+import { AutoEval } from "lastmile/lib/auto_eval";
+
+// Recommended: AutoEval client SDK (higher-level APIs)
+const client = new AutoEval({
+    apiKey: "api_token_if_LASTMILE_API_TOKEN_not_set" 
+});
+
+// Lastmile client (REST API wrappers)
+const client2 = new Lastmile({
+    bearerToken: "api_token_if_LASTMILE_API_TOKEN_not_set",
+})
 ```
 
 </TabItem>

--- a/website/docs/autoeval/datasets.mdx
+++ b/website/docs/autoeval/datasets.mdx
@@ -58,6 +58,23 @@ print(dataset_id)
 ```
 
   </TabItem>
+  <TabItem value="node.js">
+  
+  ```typescript
+import { AutoEval } from "lastmile/lib/auto_eval";
+
+const client = new AutoEval({ apiKey: "api_token_if_LASTMILE_API_TOKEN_not_set" });
+const datasetCSV = "path_to_dataset.csv"
+const datasetId = await client.uploadDataset({
+    filePath: datasetCSV,
+    name: "My New Dataset",
+    description: "This Dataset is the latest batch of application trace data" 
+})
+
+console.log(datasetId)
+```
+
+  </TabItem>
 </Tabs>
 
 ### Download a Dataset
@@ -87,6 +104,21 @@ print(dataset_df.head(5))
 ```
 
   </TabItem>
+  <TabItem value="node.js">
+  
+  ```typescript
+import { AutoEval } from "lastmile/lib/auto_eval";
+
+const client = new AutoEval({ apiKey: "api_token_if_LASTMILE_API_TOKEN_not_set" });
+const data = await client.downloadDataset(
+    datasetId,
+    /*outputFilePath*/ "optional_path_to_save_file"
+);
+
+console.table(data)
+```
+
+  </TabItem>
 </Tabs>
 
 ### List Datasets
@@ -110,6 +142,20 @@ client = AutoEval(api_token="api_token_if_LASTMILE_API_TOKEN_not_set")
 datasets = client.list_datasets()
 for dataset in datasets:
     print(f"Dataset ID: {dataset['id']}, Name: {dataset['name']}")
+```
+
+  </TabItem>
+  <TabItem value="node.js">
+  
+  ```typescript
+import { AutoEval } from "lastmile/lib/auto_eval";
+
+const client = new AutoEval({ apiKey: "api_token_if_LASTMILE_API_TOKEN_not_set" });
+const datasets = await client.listDatasets();
+
+for (const dataset of datasets) {
+    console.log(`Dataset ID: ${dataset.id}, Name: ${dataset.name}`);
+}
 ```
 
   </TabItem>

--- a/website/docs/autoeval/fine-tuning.mdx
+++ b/website/docs/autoeval/fine-tuning.mdx
@@ -122,6 +122,27 @@ print(f"Fine-tuning job completed with ID: {fine_tune_job_id}")
 ```
 
   </TabItem>
+  <TabItem value="node.js">
+  
+  ```typescript title="fine_tune"
+import { AutoEval } from "lastmile/lib/auto_eval";
+const client = new AutoEval({
+    apiKey: "api_token_if_LASTMILE_API_TOKEN_not_set",
+});
+const modelName = "My Custom Evaluation Metric";
+const fineTuningJobId = await client.fineTuneModel({
+    trainDatasetId: datasetId,
+    modelName,
+    selectedColumns: ["input", "output", "ground_truth"],
+    waitForCompletion: false, // Set to  true to block until completion
+});
+
+console.log(`Fine-tuning job initiated with ID: ${fineTuningJobId}. Waiting for completion...`);
+await client.waitForFineTuneJob(fineTuningJobId);
+console.log(`Fine-tuning job completed with ID: ${fineTuningJobId}`);
+```
+
+  </TabItem>
 </Tabs>
 
 #### UI
@@ -168,6 +189,41 @@ eval_results_df = client.evaluate_data(
     }),
     metrics=[fine_tuned_metric],
 )
+```
+
+  </TabItem>
+    <TabItem value="node.js">
+  
+  ```typescript title="run_inference"
+import { AutoEval, Metric } from "lastmile/lib/auto_eval";
+const client = new AutoEval({
+    apiKey: "api_token_if_LASTMILE_API_TOKEN_not_set",
+});
+
+const metric: Metric = {
+    name: "My Custom Evaluation Metric",
+};
+
+console.log(`Waiting for fine-tuned model '${metric.name}' to be available as a metric...`);
+const fineTunedMetric = await client.waitForMetricOnline(metric);
+console.log(`Fine-tuned model '${metric.name}' is now available as a metric with ID: ${fineTunedMetric.id}.`);
+
+// Run evals on your test/holdout dataset to see how the model is performing
+const testResults = await client.evaluateDataset(testDatasetId, fineTunedMetric);
+console.table(testResults);
+
+// Run evals on any application data
+const results = await client.evaluateData(
+    /*data*/ [
+      {
+        "input": "What is the meaning of life?",
+        "output": "42",
+        "ground_truth": "Life, universe and everything"
+      }
+    ],
+    /*metrics*/ [fineTunedMetric]
+);
+console.table(results);
 ```
 
   </TabItem>

--- a/website/docs/autoeval/guardrails.mdx
+++ b/website/docs/autoeval/guardrails.mdx
@@ -60,6 +60,55 @@ guard(
 ```
 
 </TabItem>
+  <TabItem value="node.js">
+  
+  ```typescript
+import { AutoEval, Metric } from "lastmile/lib/auto_eval";
+
+async function guard(
+    input: string,
+    output: string,
+    context: string,
+    metric: Metric,
+    threshold: number = 0.5
+): Promise<boolean> {
+    const client = new AutoEval({
+      apiKey: "api_token_if_LASTMILE_API_TOKEN_not_set",
+    });
+
+    // Evaluate the data
+    const result = await client.evaluateData(
+      /*data*/ [
+        {
+          "input": input,
+          "output": output,
+          "ground_truth": context
+        }
+      ], 
+      metric
+    );
+
+    // Extract the score
+    const scoreColumnName = `${metric.name}_score`;
+    const score = result[0][scoreColumnName];
+
+    // Return whether the score meets the threshold
+    return score >= threshold;
+}
+
+const faithfulnessMetric: Metric = { name: "Faithfulness" };
+
+const isFaithful = await guard(
+    /*input*/   "Where did the author grow up?",
+    /*output*/  "France",
+    /*context*/ "England",
+    faithfulnessMetric
+);
+
+console.log(`Is the response faithful? ${isFaithful}`);
+```
+
+</TabItem>
 </Tabs>
 
 ### Fine-tune a custom guardrail

--- a/website/docs/autoeval/labeling.mdx
+++ b/website/docs/autoeval/labeling.mdx
@@ -55,6 +55,30 @@ labeled_dataset = client.download_dataset(dataset_id)
 print(f"Labeling Job with ID: {job_id} Completed")
 ```
 
+</TabItem>
+<TabItem value="node.js">
+  
+  ```typescript title="label_dataset"
+import { AutoEval, BuiltinMetrics } from "lastmile/lib/auto_eval";
+
+const client = new AutoEval({
+  apiKey: "api_token_if_LASTMILE_API_TOKEN_not_set",
+});
+
+const jobId = await client.labelDataset({
+    datasetId,
+    promptTemplate: BuiltinMetrics.FAITHFULNESS, // Or a custom evaluation prompt criteria
+    waitForCompletion: false, // Set to true to wait for the job to complete
+});
+
+console.log(`Waiting for labeling job ${jobId} to complete...`);
+await client.waitForLabelDatasetJob(jobId);
+console.log(`Labeling Job with ID: ${jobId} Completed`);
+const labeledData = client.downloadDataset(datasetId);
+
+console.table(labeledData);
+```
+
   </TabItem>
 </Tabs>
 

--- a/website/docs/autoeval/metrics.mdx
+++ b/website/docs/autoeval/metrics.mdx
@@ -84,6 +84,44 @@ print(eval_result)
 ```
 
 </TabItem>
+<TabItem value="node.js">
+  
+  ```typescript
+import { AutoEval, BuiltinMetrics } from "lastmile/lib/auto_eval";
+
+const client = new AutoEval({
+    apiKey: "api_token_if_LASTMILE_API_TOKEN_not_set",
+});
+
+const query = "What is Albert Einstein famous for?";
+const contextRetrieved = `
+    Albert Einstein was a German-born theoretical physicist who developed
+    the theory of relativity, one of the two pillars of modern physics. His
+    work is also known for its influence on the philosophy of science. He is
+    best known to the general public for his mass-energy equivalence formula
+    E = mc², which has been dubbed 'the world's most famous equation'. He
+    received the 1921 Nobel Prize in Physics 'for his services to theoretical
+    physics, and especially for his discovery of the law of the photoelectric
+    effect', a pivotal step in the development of quantum theory.`;
+
+const llmResponse = "Albert Einstein is famous for the formula E = mc² and Brownian motion.";
+
+// Evaluate data using the FAITHFULNESS metric
+const evalResult = await client.evaluateData(
+    [
+      {
+        "input": query,
+        "output": llmResponse,
+        "ground_truth": contextRetrieved,
+      },
+    ],
+    [BuiltinMetrics.FAITHFULNESS]
+);
+
+console.table(evalResult);
+```
+
+</TabItem>
 </Tabs>
 
 <img
@@ -144,6 +182,48 @@ eval_result = client.evaluate_data(
 )
 
 print(eval_result)
+```
+
+</TabItem>
+<TabItem value="node.js">
+  
+  ```typescript
+import { AutoEval, BuiltinMetrics } from "lastmile/lib/auto_eval";
+
+const client = new AutoEval({
+    apiKey: "api_token_if_LASTMILE_API_TOKEN_not_set",
+});
+
+const sourceDocument = `
+    Albert Einstein was a German-born theoretical physicist who developed
+    the theory of relativity, one of the two pillars of modern physics. His work
+    is also known for its influence on the philosophy of science. He is best known
+    to the general public for his mass-energy equivalence formula E = mc²,
+    which has been dubbed 'the world's most famous equation'. Einstein received
+    the 1921 Nobel Prize in Physics 'for his services to theoretical physics, and
+    especially for his discovery of the law of the photoelectric effect', a
+    pivotal step in the development of quantum theory. In his later years,
+    Einstein focused on unified field theory and became increasingly isolated
+    from the mainstream of modern physics.`;
+  
+const llmSummary = `
+    Albert Einstein, a German-born physicist, developed the theory of
+    relativity and the famous equation E = mc². He won the 1921 Nobel Prize
+    in Physics for his work on the photoelectric effect, contributing to
+    quantum theory. Later, he worked on unified field theory.`;
+
+// Evaluate data using the SUMMARIZATION metric
+const evalResult = await client.evaluateData(
+    [
+      {
+        "output": llmSummary,
+        "ground_truth": sourceDocument,
+      },
+    ],
+    [BuiltinMetrics.SUMMARIZATION]
+);
+
+console.table(evalResult);
 ```
 
 </TabItem>
@@ -213,6 +293,47 @@ print(eval_result)
 ```
 
 </TabItem>
+<TabItem value="node.js">
+  
+  ```typescript
+import { AutoEval, BuiltinMetrics } from "lastmile/lib/auto_eval";
+
+const client = new AutoEval({
+    apiKey: "api_token_if_LASTMILE_API_TOKEN_not_set",
+});
+
+const expectedResponse = `
+    Albert Einstein transformed our understanding of the universe with his
+    groundbreaking theories. His special and general theories of relativity
+    redefined concepts of space, time, and gravity. Einstein's equation E = mc²
+    revealed the fundamental relationship between mass and energy. His
+    explanation of the photoelectric effect was crucial to the emergence of
+    quantum physics, for which he received the Nobel Prize. Throughout his career,
+    Einstein's innovative thinking and scientific contributions reshaped the
+    field of physics.`;
+  
+const llmResponse = `
+    Albert Einstein revolutionized physics with his theory of relativity.
+    He proposed that space and time are interconnected and that the speed of
+    light is constant in all reference frames. His famous equation E = mc²
+    showed that mass and energy are equivalent. Einstein's work on the
+    photoelectric effect contributed to the development of quantum theory,
+    earning him the Nobel Prize in Physics.`;
+
+const evalResult = await client.evaluateData(
+    [
+      {
+        "input": expectedResponse,
+        "output": llmResponse,
+      },
+    ],
+    [BuiltinMetrics.RELEVANCE]
+);
+
+console.table(evalResult);
+```
+
+</TabItem>
 </Tabs>
 
 <img
@@ -264,6 +385,34 @@ eval_result = client.evaluate_data(
 )
 
 print(eval_result)
+```
+
+</TabItem>
+<TabItem value="node.js">
+  
+  ```typescript
+import { AutoEval, BuiltinMetrics } from "lastmile/lib/auto_eval";
+
+const client = new AutoEval({
+    apiKey: "api_token_if_LASTMILE_API_TOKEN_not_set",
+});
+
+const query = "Can you tell me the flight status for SA450?";
+const contextRetrieved = "Flight SA450 is on schedule and will depart from JFK Terminal 2, Gate 15 at 4:00PM.";
+const llmResponse = "SA450: On Schedule, JFK Terminal 2, Gate 15, 4:00PM departure";
+
+const evalResult = await client.evaluateData(
+    [
+      {
+        "input": query,
+        "output": llmResponse,
+        "ground_truth": contextRetrieved
+      },
+    ],
+    [BuiltinMetrics.ANSWER_CORRECTNESS]
+);
+
+console.table(evalResult);
 ```
 
 </TabItem>
@@ -472,6 +621,28 @@ eval_result = client.evaluate_data(
 )
 
 print(eval_result)
+```
+
+</TabItem>
+<TabItem value="node.js">
+  
+  ```typescript
+import { AutoEval, BuiltinMetrics } from "lastmile/lib/auto_eval";
+
+const client = new AutoEval({
+    apiKey: "api_token_if_LASTMILE_API_TOKEN_not_set",
+});
+
+const evalResult = await client.evaluateData(
+    [
+      {
+        "output": "This is the worst airline I've ever flown with. You've lost my bags!",
+      },
+    ],
+    [BuiltinMetrics.TOXICITY]
+);
+
+console.table(evalResult);
 ```
 
 </TabItem>

--- a/website/docs/autoeval/models.mdx
+++ b/website/docs/autoeval/models.mdx
@@ -85,6 +85,47 @@ dataset_result_df = client.evaluate_dataset(
 ```
 
 </TabItem>
+<TabItem value="node.js">
+
+```typescript
+import { AutoEval, Metric } from "lastmile/lib/auto_eval";
+
+const client = new AutoEval({
+  apiKey: "api_token_if_LASTMILE_API_TOKEN_not_set",
+});
+
+const query = "Where did the author grow up?";
+const expectedResponse = "England";
+const llmResponse = "France";
+
+// Evaluate data using a direct array of DataRows
+const dataResult = await client.evaluateData(
+  [
+    {
+      input: query,
+      output: llmResponse,
+      ground_truth: expectedResponse,
+    },
+  ],
+  [{ name: "Faithfulness" }] // Metrics
+);
+
+console.table(dataResult);
+
+// Evaluate data in a dataset
+const datasetId = "your_dataset_id"; // Replace with your dataset ID
+const datasetResult = await client.evaluateDataset(
+    datasetId,
+    /*metrics*/ [
+      { id: "cm2plr07q000ipkr4o8qhj4oe" }, // Metric by ID
+      { name: "Summarization" }, // Metric by name
+    ]
+);
+
+console.table(datasetResult);
+```
+
+</TabItem>
 </Tabs>
 
 You can reference any metric by its name as it appears in the [Model Console](https://lastmileai.dev/models).

--- a/website/docs/overview.mdx
+++ b/website/docs/overview.mdx
@@ -38,16 +38,21 @@ print(f'Evlauation result:', result)`,
     {
       language: "javascript",
       label: "node.js",
-      code: `import {Lastmile, Metric} from 'lastmile';
+      code: `import { AutoEval, Metric, BuiltinMetrics } from "lastmile/lib/auto_eval";;
 
-const client = new Lastmile();
+const client = new AutoEval();
+const result = await client.evaluateData(
+  /*data*/ [
+    {
+      input: "Where did the author grow up?",
+      output: "France",
+      ground_truth: "England",
+    },
+  ],
+  /*metrics*/ [BuiltinMetrics.FAITHFULNESS]
+);
 
-const response = await client.evaluation.evaluate({
-    input: ["Where did the author grow up?"],
-    output: ["France"],
-    groundTruth: ["England"]
-    metric: Metric(name: "Faithfulness")
-  });
+console.table(result);
 `,
 },
 ]}

--- a/website/docs/quickstart.mdx
+++ b/website/docs/quickstart.mdx
@@ -103,6 +103,32 @@ print(eval_result)
 ```
 
 </TabItem>
+<TabItem value="node.js">
+  
+  ```typescript
+import { AutoEval, Metric, BuiltinMetrics } from "lastmile/lib/auto_eval";
+
+const client = new AutoEval({ apiKey: "api_token_if_LASTMILE_API_TOKEN_not_set" });
+
+const query = "Where did the author grow up?"
+const expectedResponse = "England"
+const llmResponse = "France"
+
+const result = await client.evaluateData(
+  /*data*/ [
+    {
+      input: query,
+      output: llmResponse,
+      ground_truth: expectedResponse,
+    },
+  ],
+  /*metrics*/ [BuiltinMetrics.FAITHFULNESS]
+);
+
+console.table(result);
+```
+
+</TabItem>
 </Tabs>
 
 You can reference any metric by its name as it appears in the [Model Console](https://lastmileai.dev/models).


### PR DESCRIPTION
## Summary

Now that we have an `AutoEval` client implemented in Node (see https://github.com/lastmile-ai/lastmile-node/blob/main/src/lib/auto_eval.ts), we add code samples for Node.js usage of AutoEval to the docs.

## Changelist

Added code samples for every place we have a Python code sample already.

## Test Plan

Tested the code samples by running them to ensure they work as advertised.

---
